### PR TITLE
add unit test for different array structures

### DIFF
--- a/2darray_test.go
+++ b/2darray_test.go
@@ -1,0 +1,56 @@
+package ikea
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"testing"
+)
+
+type Holder struct {
+	vals [50000000][10]uint16
+	buffer    *bytes.Buffer `ikea:"-"`
+}
+
+func (h *Holder) Init() {
+	h.buffer = new(bytes.Buffer)
+}
+
+func (h *Holder) compress() error {
+	return Pack(h.buffer, h)
+}
+
+
+var _holder Holder
+
+func init() {
+	_holder.Init()
+
+	for i := range _holder.vals {
+		for j := range _holder.vals[i] {
+			v := rand.Uint32()
+			_holder.vals[i][j] = uint16(v)
+		}
+	}
+}
+
+func Test2DArrayPackingAndUnpacking(t *testing.T) {
+	if err := _holder.compress(); err != nil {
+		panic(err)
+	}
+
+	h2 := Holder{}
+	h2.Init()
+	err := Unpack(_holder.buffer, &h2)
+	if err != nil {
+		panic(err)
+	}
+
+	for i := range _holder.vals {
+		for j := range _holder.vals[i] {
+			if _holder.vals[i][j] != h2.vals[i][j] {
+				panic(fmt.Sprintf("diff values. At vals[%d][%d]", i, j))
+			}
+		}
+	}
+}

--- a/2darray_test.go
+++ b/2darray_test.go
@@ -23,26 +23,25 @@ import (
 //	return Pack(h.buffer, h)
 //}
 
-type HolderSmall struct {
-	vals [10][10]uint16
-	buffer    *bytes.Buffer `ikea:"-"`
+type arr2dHolderSmall struct {
+	vals   [10][10]uint16
+	buffer *bytes.Buffer `ikea:"-"`
 }
 
-func (h *HolderSmall) Init() {
+func (h *arr2dHolderSmall) Init() {
 	h.buffer = new(bytes.Buffer)
 }
 
-func (h *HolderSmall) compress() error {
+func (h *arr2dHolderSmall) compress() error {
 	return Pack(h.buffer, h)
 }
 
-
 // var _holderL HolderLarge
-var _holderS HolderSmall
+var _arr2dHolderS arr2dHolderSmall
 
 func init() {
 	//_holderL.Init()
-	_holderS.Init()
+	_arr2dHolderS.Init()
 
 	//for i := range _holderL.vals {
 	//	for j := range _holderL.vals[i] {
@@ -51,10 +50,10 @@ func init() {
 	//	}
 	//}
 
-	for i := range _holderS.vals {
-		for j := range _holderS.vals[i] {
+	for i := range _arr2dHolderS.vals {
+		for j := range _arr2dHolderS.vals[i] {
 			v := rand.Uint32()
-			_holderS.vals[i][j] = uint16(v)
+			_arr2dHolderS.vals[i][j] = uint16(v)
 		}
 	}
 }
@@ -81,20 +80,20 @@ func init() {
 //}
 
 func TestSmall2DArrayPackingAndUnpacking(t *testing.T) {
-	if err := _holderS.compress(); err != nil {
+	if err := _arr2dHolderS.compress(); err != nil {
 		t.Fatal(err)
 	}
 
-	h2 := HolderSmall{}
+	h2 := arr2dHolderSmall{}
 	h2.Init()
-	err := Unpack(_holderS.buffer, &h2)
+	err := Unpack(_arr2dHolderS.buffer, &h2)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	for i := range _holderS.vals {
-		for j := range _holderS.vals[i] {
-			if _holderS.vals[i][j] != h2.vals[i][j] {
+	for i := range _arr2dHolderS.vals {
+		for j := range _arr2dHolderS.vals[i] {
+			if _arr2dHolderS.vals[i][j] != h2.vals[i][j] {
 				t.Fatal(fmt.Sprintf("diff values. At vals[%d][%d]", i, j))
 			}
 		}

--- a/2darray_test.go
+++ b/2darray_test.go
@@ -8,18 +8,20 @@ import (
 )
 
 // Causes error: too much data in section SBSS / SNOPTRBSS
-type HolderLarge struct {
-	vals [50000000][10]uint16
-	buffer    *bytes.Buffer `ikea:"-"`
-}
-
-func (h *HolderLarge) Init() {
-	h.buffer = new(bytes.Buffer)
-}
-
-func (h *HolderLarge) compress() error {
-	return Pack(h.buffer, h)
-}
+// this is a issue with Go: https://github.com/golang/go/issues/17378
+// This test is currently removed, until go fixes this issue.
+//type HolderLarge struct {
+//	vals [100000000][10]uint16
+//	buffer    *bytes.Buffer `ikea:"-"`
+//}
+//
+//func (h *HolderLarge) Init() {
+//	h.buffer = new(bytes.Buffer)
+//}
+//
+//func (h *HolderLarge) compress() error {
+//	return Pack(h.buffer, h)
+//}
 
 type HolderSmall struct {
 	vals [10][10]uint16
@@ -35,19 +37,19 @@ func (h *HolderSmall) compress() error {
 }
 
 
-var _holderL HolderLarge
-var _holderS HolderLarge
+// var _holderL HolderLarge
+var _holderS HolderSmall
 
 func init() {
-	_holderL.Init()
+	//_holderL.Init()
 	_holderS.Init()
 
-	for i := range _holderL.vals {
-		for j := range _holderL.vals[i] {
-			v := rand.Uint32()
-			_holderL.vals[i][j] = uint16(v)
-		}
-	}
+	//for i := range _holderL.vals {
+	//	for j := range _holderL.vals[i] {
+	//		v := rand.Uint32()
+	//		_holderL.vals[i][j] = uint16(v)
+	//	}
+	//}
 
 	for i := range _holderS.vals {
 		for j := range _holderS.vals[i] {
@@ -57,26 +59,26 @@ func init() {
 	}
 }
 
-func TestLarge2DArrayPackingAndUnpacking(t *testing.T) {
-	if err := _holderL.compress(); err != nil {
-		t.Fatal(err)
-	}
-
-	h2 := HolderLarge{}
-	h2.Init()
-	err := Unpack(_holderL.buffer, &h2)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	for i := range _holderL.vals {
-		for j := range _holderL.vals[i] {
-			if _holderL.vals[i][j] != h2.vals[i][j] {
-				t.Fatal(fmt.Sprintf("diff values. At vals[%d][%d]", i, j))
-			}
-		}
-	}
-}
+//func TestLarge2DArrayPackingAndUnpacking(t *testing.T) {
+//	if err := _holderL.compress(); err != nil {
+//		t.Fatal(err)
+//	}
+//
+//	h2 := HolderLarge{}
+//	h2.Init()
+//	err := Unpack(_holderL.buffer, &h2)
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//
+//	for i := range _holderL.vals {
+//		for j := range _holderL.vals[i] {
+//			if _holderL.vals[i][j] != h2.vals[i][j] {
+//				t.Fatal(fmt.Sprintf("diff values. At vals[%d][%d]", i, j))
+//			}
+//		}
+//	}
+//}
 
 func TestSmall2DArrayPackingAndUnpacking(t *testing.T) {
 	if err := _holderS.compress(); err != nil {

--- a/array_test.go
+++ b/array_test.go
@@ -1,0 +1,51 @@
+package ikea
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"testing"
+)
+
+type arr1DHolder struct {
+	vals   [10]uint16
+	buffer *bytes.Buffer `ikea:"-"`
+}
+
+func (h *arr1DHolder) Init() {
+	h.buffer = new(bytes.Buffer)
+}
+
+func (h *arr1DHolder) compress() error {
+	return Pack(h.buffer, h)
+}
+
+// var _holderL HolderLarge
+var _arr1dHolder arr1DHolder
+
+func init() {
+	_arr1dHolder.Init()
+	for i := range _arr1dHolder.vals {
+		v := rand.Uint32()
+		_arr1dHolder.vals[i] = uint16(v)
+	}
+}
+
+func Test1DArrayPackingAndUnpacking(t *testing.T) {
+	if err := _arr1dHolder.compress(); err != nil {
+		t.Fatal(err)
+	}
+
+	h2 := arr1DHolder{}
+	h2.Init()
+	err := Unpack(_arr1dHolder.buffer, &h2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := range _arr1dHolder.vals {
+		if _arr1dHolder.vals[i] != h2.vals[i] {
+			t.Fatal(fmt.Sprintf("diff values. At vals[%d]", i))
+		}
+	}
+}


### PR DESCRIPTION
Yields the error:
```
=== RUN   TestPacking
--- FAIL: TestPacking (0.15s)
panic: diff values. At vals[0][0] [recovered]
	panic: diff values. At vals[0][0]

goroutine 5 [running]:
testing.tRunner.func1(0xc0000bc100)
	/usr/lib/go/src/testing/testing.go:830 +0x392
panic(0x520f80, 0xc00005a000)
	/usr/lib/go/src/runtime/panic.go:522 +0x1b5
github.com/ikkerens/ikeapack.TestPacking(0xc0000bc100)
	/home/anders/dev/ikeapack/2darray_test.go:52 +0x22b
testing.tRunner(0xc0000bc100, 0x55fd48)
	/usr/lib/go/src/testing/testing.go:865 +0xc0
created by testing.(*T).Run
	/usr/lib/go/src/testing/testing.go:916 +0x35a
FAIL	github.com/ikkerens/ikeapack	8.785s

Process finished with exit code 1
```